### PR TITLE
chore: add a function to load all local schemas at start

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {erl_opts, [debug_info]}.
 {deps, [
-       {jesse, {git, "https://github.com/for-GET/jesse.git", {branch, "master"}}}
+       {jesse, {git, "https://github.com/for-GET/jesse.git", {tag, "1.8.1"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,17 @@
 {erl_opts, [debug_info]}.
 {deps, [
-       {jesse, {git, "https://github.com/for-GET/jesse.git", {tag, "1.8.1"}}}
-       ]}.
+    {jesse, "1.8.1"}
+]}.
+
+{project_plugins, [
+    {erlfmt, "~>1.3"}
+]}.
+
+{erlfmt, [
+    write,
+    {files, [
+        "rebar.config",
+        "src/*.app.src",
+        "src/**/{*.erl, *.hrl}"
+    ]}
+]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,8 @@
-[{<<"jesse">>,
-  {git,"https://github.com/for-GET/jesse.git",
-       {ref,"37fee7373db7eac85dda6ede0d7cc93c10f69475"}},
-  0}].
+{"1.2.0",
+[{<<"jesse">>,{pkg,<<"jesse">>,<<"1.8.1">>},0}]}.
+[
+{pkg_hash,[
+ {<<"jesse">>, <<"C9E3670C7EE40F719734E3BC716578143AABA93FC7525A02A7D5CB300B3AD71E">>}]},
+{pkg_hash_ext,[
+ {<<"jesse">>, <<"0EDED3F18623FDA2F25989804A06CF518B4ACF2E9365B18C8E8C013D7E3C906F">>}]}
+].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,15 +1,4 @@
-{"1.2.0",
 [{<<"jesse">>,
   {git,"https://github.com/for-GET/jesse.git",
-       {ref,"cf075d213ae9e9c54a748c93cc64d5350e646f9a"}},
-  0},
- {<<"jsx">>,{pkg,<<"jsx">>,<<"3.1.0">>},1},
- {<<"rfc3339">>,{pkg,<<"rfc3339">>,<<"0.2.2">>},1}]}.
-[
-{pkg_hash,[
- {<<"jsx">>, <<"D12516BAA0BB23A59BB35DCCAF02A1BD08243FCBB9EFE24F2D9D056CCFF71268">>},
- {<<"rfc3339">>, <<"1552DF616ACA368D982E9F085A0E933B6688A3F4938A671798978EC2C0C58730">>}]},
-{pkg_hash_ext,[
- {<<"jsx">>, <<"0C5CC8FDC11B53CC25CF65AC6705AD39E54ECC56D1C22E4ADB8F5A53FB9427F3">>},
- {<<"rfc3339">>, <<"986D7F9BAC6891AA4D5051690058DE4E623245620BBEADA7F239F85C4DF8F23C">>}]}
-].
+       {ref,"7aa57b759a9f2f205207a0d933cad9c26723acf7"}},
+  0}].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,4 @@
 [{<<"jesse">>,
   {git,"https://github.com/for-GET/jesse.git",
-       {ref,"7aa57b759a9f2f205207a0d933cad9c26723acf7"}},
+       {ref,"37fee7373db7eac85dda6ede0d7cc93c10f69475"}},
   0}].

--- a/src/nova_json_schemas.app.src
+++ b/src/nova_json_schemas.app.src
@@ -1,15 +1,15 @@
-{application, nova_json_schemas,
- [{description, "An OTP library"},
-  {vsn, "0.1.0"},
-  {registered, []},
-  {applications,
-   [kernel,
-    stdlib,
-    jesse
-   ]},
-  {env,[]},
-  {modules, []},
+{application, nova_json_schemas, [
+    {description, "An OTP library"},
+    {vsn, "0.1.0"},
+    {registered, []},
+    {applications, [
+        kernel,
+        stdlib,
+        jesse
+    ]},
+    {env, []},
+    {modules, []},
 
-  {licenses, ["Apache 2.0"]},
-  {links, []}
- ]}.
+    {licenses, ["Apache 2.0"]},
+    {links, []}
+]}.


### PR DESCRIPTION
This PR solves an issue with the current version of `nova_json_schemas` and that the JSON schemas used for validation cannot refer to other JSON schemas that weren't loaded. nova_json_schemas attempts to load a schema when an endpoint with that specified schema is being called. This renders other schemas not being loaded, a big example on this usecase is the use of schema composition, where a schema refers to another schema. This PR aims to address this issue by adding the possibility to load local schemas without the need of them being called.

An example, the schemas below should not work without initially loading `address.json` schema. If they were loaded, then there should be no issues.

Schema `address.json`:
```
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "type": "object",
  "properties": {
    "city": {
      "type": "string"
    }
  }
}
```
Schema `person.json`:
```
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "type": "object",
  "properties": {
    "name": {
      "type": "string"
    },
    "shipping_address": {
      "$ref": "address.json"
    },
    "billing_address": {
      "$ref": "address.json"
    }
  }
}
```